### PR TITLE
chore(compat): widen @deepseek-ai peer ranges for the 0.1.1 rc train

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
     "react": "^18.2.0",
-    "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-session-log-export": "^0.1.0-rc.6"
+    "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-client-ui-layout": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-client-ui-settings": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-session-log-export": "^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0"
   },
   "devDependencies": {
     "@types/react": "~18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,31 +12,31 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-client-locale':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(9e8db6c5abfb5dfda585a92ec8fe7fec)
       '@deepseek-ai/dsh-client-runtime':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(5ee287bd07c00b3171c7ee342e9431a4)
       '@deepseek-ai/dsh-client-ui-conversation':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(d29c9974ac2869171d8d115d6553c6f8)
       '@deepseek-ai/dsh-client-ui-layout':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.0-rc.6(5ee287bd07c00b3171c7ee342e9431a4))(@deepseek-ai/dsh-client-ui-slots@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-ui-theme@0.1.0-rc.6(d21d9370e2e82b1c20662b4178ea343c))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(react@18.3.1)
       '@deepseek-ai/dsh-client-ui-primitives':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-ui-settings':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.0-rc.6(963f21f11cddd09def26a2473cddd8c5))(@deepseek-ai/dsh-client-connection@0.1.0-rc.6)(@deepseek-ai/dsh-client-runtime@0.1.0-rc.6(5ee287bd07c00b3171c7ee342e9431a4))(@deepseek-ai/dsh-client-schema-form@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-ui-slots@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))(react@18.3.1)
       '@deepseek-ai/dsh-client-ui-sidebar':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.0-rc.6(9e8db6c5abfb5dfda585a92ec8fe7fec))(@deepseek-ai/dsh-client-runtime@0.1.0-rc.6(5ee287bd07c00b3171c7ee342e9431a4))(@deepseek-ai/dsh-client-ui-primitives@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-ui-slots@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(react@18.3.1)
       '@deepseek-ai/dsh-client-ui-slots':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-session-log-export':
-        specifier: ^0.1.0-rc.6
+        specifier: ^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.6(3be6cf76fd8957b0d2e0346ebb49b9f8)
       react:
         specifier: ^18.2.0


### PR DESCRIPTION
## Problem

Under strict semver, a prerelease version only satisfies a range when some comparator shares its exact `major.minor.patch` tuple. The current peer ranges (`^0.1.0-rc.6`) therefore **do not match core `0.1.1-rc.1`**, which surfaces as unmet-peer diagnostics in marketplace/health checks even though the plugin runs fine.

## Change

- Widen every `@deepseek-ai/dsh-*` peer/dev range to `^0.1.0-rc.6 || >=0.1.1-rc.0 <0.2.0`:
  - keeps the declared API floor (rc.6)
  - matches the whole 0.1.1 rc train **and** every future 0.1.x stable
  - still excludes 0.2.0
- `pnpm-lock.yaml` regenerated (`specifier` lines only; resolved versions unchanged).

## Verification

- `semver.satisfies('0.1.1-rc.1', range)` → true (strict)
- Plugin loads and renders cleanly on a live 0.1.1-rc.1 profile (mobile drawer, settings row, zero console errors).