### PR TITLE
fix(mobile): 修复手机端点击插件市场搜索框后页面被强制放大

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2067,6 +2067,15 @@ exports.COMPAT_CSS = `@media (max-width: 1023px) {
     width: 100% !important;
     max-width: 100% !important;
   }
+  /* iOS Safari auto-zooms a focused input whose computed font-size is below
+     16px. dshmarket's tab search uses the shared primitive Input at 13px;
+     raise only this market-owned field on mobile so focusing it keeps the
+     current viewport scale. Scoped to the market root to avoid changing
+     unrelated settings/search fields; pinch zoom stays available. */
+  [data-dsh-market-root] [class*="tabSearch"] input,
+  [data-dsh-market-root] input[class*="tabSearch"] {
+    font-size: 16px !important;
+  }
 
   /* ---------- dshmarket polish: Tasks operations popup ----------
      Upstream .opPanel is a small dropdown pinned to the right edge of its

--- a/src/client/styles/compat.css.ts
+++ b/src/client/styles/compat.css.ts
@@ -260,6 +260,15 @@ export const COMPAT_CSS = `@media (max-width: 1023px) {
     width: 100% !important;
     max-width: 100% !important;
   }
+  /* iOS Safari auto-zooms a focused input whose computed font-size is below
+     16px. dshmarket's tab search uses the shared primitive Input at 13px;
+     raise only this market-owned field on mobile so focusing it keeps the
+     current viewport scale. Scoped to the market root to avoid changing
+     unrelated settings/search fields; pinch zoom stays available. */
+  [data-dsh-market-root] [class*="tabSearch"] input,
+  [data-dsh-market-root] input[class*="tabSearch"] {
+    font-size: 16px !important;
+  }
 
   /* ---------- dshmarket polish: Tasks operations popup ----------
      Upstream .opPanel is a small dropdown pinned to the right edge of its


### PR DESCRIPTION
## 问题

在手机端进入 **设置 → 插件市场 → 搜索框**，一点击弹出输入法，整个页面就被放大，并且卡在这个放大状态无法恢复（设置弹层内没有可点击的外部区域来让输入框失焦）。

## 根因

`dshmarket` 的搜索框（`tabSearch`）用的是宿主共享的 primitive `Input`，字号是 **13px**。iOS Safari 在聚焦任何计算字号 **< 16px** 的 `<input>`/`<textarea>` 时，会自动放大整个视口，并且只有失焦才还原——而插件市场是在设置 modal 里，modal 外的区域不响应点击，所以放大态会一直卡住。

> 注：本插件其实已经为 `ask_user_question` 的输入框处理过同样的问题（`misc.css.ts` 里把 `customInput`/`customTextarea` 提到 16px），只是漏了插件市场这个搜索框。

## 修复

仅在移动端（`@media (max-width: 1023px)`）给市场搜索框加一条字号规则，作用域限定在 `[data-dsh-market-root]`，不碰其它设置/文件树搜索框：

\`\`\`css
[data-dsh-market-root] [class*="tabSearch"] input,
[data-dsh-market-root] input[class*="tabSearch"] {
  font-size: 16px !important;
}
\`\`\`

- ✅ 点搜索框不再触发自动放大
- ✅ 双指缩放保持可用（未改 viewport meta / maximum-scale）
- ✅ 桌面端（≥1024px）完全不受影响
- ✅ 不影响其它搜索/输入框

`src/` 与 `lib/`（构建产物）一并更新。如需我用 `pnpm build` 重建 `lib/client.js` 我可以补一个纯构建提交，但本地缺少依赖，故此处直接同步了对应内联 CSS 段。